### PR TITLE
Ensure Start Linear Address record does not throw

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,11 @@ var parse = module.exports = function(string, fn) {
 
         // Start Linear Address Record
         case 5:
-          ev.emit('error', new Error('TODO: Start Linear Address Record'));
+          // According to the Arm Technical Support Knowledge Base, this could
+          // be ignored as it does not contain any information required to
+          // program the flash memory:
+          // http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka9903.html
+          console.log('Note: Start Linear Address Record ignored.'));
         break;
 
         // Invalid format


### PR DESCRIPTION
The Arduino IDE generates a hex for [Arduboy](https://github.com/Arduboy/Arduboy#readme) images that include the _Start Linear Address_ record. Due to this record throwing in `intelhex`, flashing with [avrgirl-arduino](https://github.com/noopkat/avrgirl-arduino/) fails, as referenced in noopkat/avrgirl-arduino#30.

According to the [ARM Support knowledge base](http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.faqs/ka9903.html), the SLA record is not required for properly programming the flash, so this method should not throw. Ignoring the record seems to flash the image just fine.
